### PR TITLE
fix bugs, add tests and improve performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go 1.24.6
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.6"
+          check-latest: true
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Test
+      - name: Run tests with coverage
+        run: go test -covermode=atomic -coverprofile=coverage.out ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,26 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+# Optional: allow read access to pull request. Use with `only-new-issues` option.
+# pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.6"
+          check-latest: true
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest

--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ go.work.sum
 # env file
 .env
 
-data.txt
+*.txt

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,14 @@
 module billion-rows
 
-go 1.24
+go 1.24.6
+
+require (
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/sync v0.16.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func MustRun(args []string, stdout, stderr io.Writer) error {
 	var errg errgroup.Group
 	for i := range *fWorkers {
 		errg.Go(func() (err error) {
-			results[i], err = processChunk(data, chunks[i][0], chunks[i][1])
+			results[i], err = processChunk(data, chunks[i])
 			return err
 		})
 	}
@@ -220,10 +220,10 @@ END:
 	return input[:offset]
 }
 
-func processChunk(data string, i, end int64) (map[string]*StationStats, error) {
+func processChunk(data string, chunk [2]int64) (map[string]*StationStats, error) {
 	stats := make(map[string]*StationStats, 10_000)
-
-	buffer := make([]float64, 0, 16*1024) // 128 KiB
+	i := chunk[0]
+	end := chunk[1]
 
 	for i < end {
 		// slice of remaining data
@@ -252,26 +252,18 @@ func processChunk(data string, i, end int64) (map[string]*StationStats, error) {
 			i++
 		}
 
-		if len(buffer) == cap(buffer) {
-			// Drain buffer
-			for _, temp := range buffer {
-				if s, ok := stats[name]; ok {
-					s.Min = min(s.Min, temp)
-					s.Max = max(s.Max, temp)
-					s.Sum += temp
-					s.Count++
-				} else {
-					stats[name] = &StationStats{
-						Min:   temp,
-						Max:   temp,
-						Sum:   temp,
-						Count: 1,
-					}
-				}
-			}
-			buffer = buffer[:0]
+		if s, ok := stats[name]; ok {
+			s.Min = min(s.Min, temp)
+			s.Max = max(s.Max, temp)
+			s.Sum += temp
+			s.Count++
 		} else {
-			buffer = append(buffer, temp)
+			stats[name] = &StationStats{
+				Min:   temp,
+				Max:   temp,
+				Sum:   temp,
+				Count: 1,
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,101 +1,125 @@
 package main
 
 import (
-	"bytes"
 	"errors"
+	"flag"
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"runtime"
+	"runtime/pprof"
 	"sort"
-	"sync"
+	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type StationStats struct {
-	Min   int64
-	Max   int64
-	Sum   int64
 	Count int64
+	Min   float64
+	Max   float64
+	Sum   float64
 }
 
-var numWorkers = runtime.NumCPU()
-
 func main() {
-	filename := "data.txt"
+	if err := MustRun(os.Args, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
 
-	fmt.Println("Billion row challenge go version")
-	fmt.Printf("Using %d CPU cores as workers\n", numWorkers)
-
-	if len(os.Args) > 1 && os.Args[1] == "-generate" {
-
-		generator := NewBillionRowGenerator()
-
-		if err := generator.LoadStations("weather_stations.csv"); err != nil {
-			log.Fatalf("Error loading stations: %v", err)
-		}
-
-		if _, err := os.Stat(filename); err == nil {
-			fmt.Printf("File %s already exists. Overwrite? (y/N): ", filename)
-			var response string
-			fmt.Scanln(&response)
-			if response != "y" && response != "Y" {
-				fmt.Println("Generation cancelled")
-				return
-			}
-		}
-
-		totalStart := time.Now()
-		if err := generator.Generate(filename); err != nil {
-			log.Fatalf("Error generating data: %v", err)
-		}
-		totalDuration := time.Since(totalStart)
-
-		fmt.Printf("\nGENERATION COMPLETE\n")
-		fmt.Printf("Total time: %v\n", totalDuration)
-		return
+func MustRun(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
+	fWorkers := flags.Int("w", 0, "workers (default: num of logical CPUs)")
+	fFile := flags.String("f", "data.txt", "path to data txt file")
+	fProfileMem := flags.String("profmem", "", "generate memory profile file")
+	fProfileCPU := flags.String("profcpu", "", "generate CPU profile file")
+	fGenerate := flags.Bool("generate", false, "generate the data file")
+	if err := flags.Parse(args[1:]); err != nil {
+		return err
 	}
 
-	if _, err := os.Stat(filename); errors.Is(err, os.ErrNotExist) {
-		fmt.Printf("File %s does not exist. Generate data first with -generate\n", filename)
-		log.Fatalf("file %s does not exist", filename)
+	if *fWorkers == 0 {
+		*fWorkers = runtime.NumCPU()
 	}
 
-	file, err := os.Open(filename)
+	if *fProfileCPU != "" {
+		f, err := os.Create(*fProfileCPU)
+		if err != nil {
+			return fmt.Errorf("creating CPU profile file: %v", err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			return fmt.Errorf("starting CPU profiler: %v", err)
+		}
+		defer func() {
+			pprof.StopCPUProfile()
+			_ = f.Close()
+		}()
+	}
+	if *fProfileMem != "" {
+		f, err := os.Create("mem.prof")
+		if err != nil {
+			return fmt.Errorf("creating memory profile file: %v", err)
+		}
+		defer func() { _ = f.Close() }()
+
+		runtime.GC() // Force GC to get up-to-date mem stats
+
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			return fmt.Errorf("writing memory profile: %v", err)
+		}
+	}
+
+	_, _ = fmt.Fprintln(stderr, "Billion row challenge go version")
+	_, _ = fmt.Fprintf(stderr, "Using %d parallel workers\n", *fWorkers)
+
+	if *fGenerate {
+		return generate(*fFile)
+	}
+
+	if _, err := os.Stat(*fFile); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf(
+			"file %s does not exist, generate data first with -generate", *fFile,
+		)
+	}
+
+	file, err := os.Open(*fFile)
 	if err != nil {
-		log.Fatalf("Error opening file: %v", err)
+		return fmt.Errorf("opening file: %v", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	start := time.Now()
 
 	data, cleanup, err := mmapFile(file)
 	if err != nil {
-		log.Fatalf("Error memory-mapping file: %v", err)
+		return fmt.Errorf("memory-mapping file: %v", err)
 	}
 	defer cleanup()
 
 	fileInfo, err := file.Stat()
 	if err != nil {
-		log.Fatalf("Error getting file info: %v", err)
+		return fmt.Errorf("getting file info: %v", err)
 	}
 	fileSize := fileInfo.Size()
 
-	chunks := calculateChunks(data, fileSize)
+	chunks := calculateChunks(data, fileSize, *fWorkers)
+	results := make([]map[string]*StationStats, *fWorkers)
 
-	resultsChan := make(chan map[string]*StationStats, numWorkers)
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-
-	for i := 0; i < numWorkers; i++ {
-		go processChunk(data, chunks[i], &wg, resultsChan)
+	var errg errgroup.Group
+	for i := range *fWorkers {
+		errg.Go(func() (err error) {
+			results[i], err = processChunk(data, chunks[i])
+			return err
+		})
+	}
+	if err := errg.Wait(); err != nil {
+		return err
 	}
 
-	wg.Wait()
-	close(resultsChan)
-
-	finalStats := make(map[string]*StationStats, 10000)
-	for workerResult := range resultsChan {
+	finalStats := make(map[string]StationStats, 10000)
+	for _, workerResult := range results {
 		for station, stats := range workerResult {
 			if existing, ok := finalStats[station]; ok {
 				existing.Min = min(existing.Min, stats.Min)
@@ -103,28 +127,30 @@ func main() {
 				existing.Sum += stats.Sum
 				existing.Count += stats.Count
 			} else {
-				finalStats[station] = stats
+				finalStats[station] = *stats
 			}
 		}
 	}
 
 	duration := time.Since(start)
 
-	printResults(finalStats, duration, fileSize)
+	printResults(stdout, finalStats)
+	printResultStats(stderr, duration, fileSize)
+	return nil
 }
 
-func calculateChunks(data []byte, fileSize int64) [][2]int64 {
+func calculateChunks(data string, fileSize int64, numWorkers int) [][2]int64 {
 	chunks := make([][2]int64, numWorkers)
 	chunkSize := fileSize / int64(numWorkers)
 
 	var currentPos int64 = 0
-	for i := 0; i < numWorkers; i++ {
+	for i := range numWorkers {
 		start := currentPos
 		end := start + chunkSize
 		if end >= fileSize {
 			end = fileSize
 		} else {
-			newlineIndex := bytes.IndexByte(data[end:], '\n')
+			newlineIndex := strings.IndexByte(data[end:], '\n')
 			if newlineIndex != -1 {
 				end += int64(newlineIndex) + 1
 			} else {
@@ -141,43 +167,98 @@ func calculateChunks(data []byte, fileSize int64) [][2]int64 {
 	return chunks
 }
 
-func processChunk(data []byte, chunk [2]int64, wg *sync.WaitGroup, resultsChan chan<- map[string]*StationStats) {
-	defer wg.Done()
+func readNameUntilSemicolon(input string) string {
+	s := input
+	var offset int
 
-	stats := make(map[string]*StationStats, 10000)
-	chunkData := data[chunk[0]:chunk[1]]
-
-	var line []byte
-	for len(chunkData) > 0 {
-		idx := bytes.IndexByte(chunkData, '\n')
-		if idx == -1 {
-			line = chunkData
-			chunkData = nil
-		} else {
-			line = chunkData[:idx]
-			chunkData = chunkData[idx+1:]
+	for len(s) > 7 {
+		if s[0] == ';' {
+			goto END
+		}
+		if s[1] == ';' {
+			offset++
+			goto END
+		}
+		if s[2] == ';' {
+			offset += 2
+			goto END
+		}
+		if s[3] == ';' {
+			offset += 3
+			goto END
+		}
+		if s[4] == ';' {
+			offset += 4
+			goto END
+		}
+		if s[5] == ';' {
+			offset += 5
+			goto END
+		}
+		if s[6] == ';' {
+			offset += 6
+			goto END
+		}
+		if s[7] == ';' {
+			offset += 7
+			goto END
 		}
 
-		if len(line) == 0 {
-			continue
+		s = s[8:]
+		offset += 8
+	}
+	// tail
+	for i := range len(s) {
+		if s[i] == ';' {
+			offset += i
+			goto END
+		}
+	}
+	// no semicolon found; return whole input
+	return input
+END:
+	return input[:offset]
+}
+
+func processChunk(data string, chunk [2]int64) (map[string]*StationStats, error) {
+	stats := make(map[string]*StationStats, 10_000)
+	i := chunk[0]
+	end := chunk[1]
+
+	for i < end {
+		// slice of remaining data
+		remaining := data[i:end]
+
+		// extract name
+		name := readNameUntilSemicolon(remaining)
+		if len(name) == len(remaining) {
+			// no semicolon found, malformed
+			break
+		}
+		i += int64(len(name)) + 1 // skip name + ';'
+
+		// extract temperature until '\n'
+		start := i
+		for i < end && data[i] != '\n' {
+			i++
 		}
 
-		sepIdx := bytes.LastIndexByte(line, ';')
-		if sepIdx == -1 {
-			continue
+		temp, ok := parseTemp(data[start:i])
+		if !ok {
+			return nil, fmt.Errorf("malformed number: %q", data[start:i])
 		}
 
-		stationName := string(line[:sepIdx])
-		tempStr := line[sepIdx+1:]
-		temp := parseTemp(tempStr)
+		if i < end && data[i] == '\n' {
+			i++
+		}
 
-		if s, ok := stats[stationName]; ok {
+		if s, ok := stats[name]; ok {
 			s.Min = min(s.Min, temp)
 			s.Max = max(s.Max, temp)
 			s.Sum += temp
 			s.Count++
 		} else {
-			stats[stationName] = &StationStats{
+			stats[name] = &StationStats{
 				Min:   temp,
 				Max:   temp,
 				Sum:   temp,
@@ -186,72 +267,131 @@ func processChunk(data []byte, chunk [2]int64, wg *sync.WaitGroup, resultsChan c
 		}
 	}
 
-	resultsChan <- stats
+	return stats, nil
 }
 
-func parseTemp(s []byte) int64 {
-	var val int64
-	var negative bool
-
-	if s[0] == '-' {
-		negative = true
-		s = s[1:]
-	}
-
-	val = int64(s[len(s)-1] - '0')
-	s = s[:len(s)-2]
-
-	place := int64(10)
-	for i := len(s) - 1; i >= 0; i-- {
-		val += int64(s[i]-'0') * place
-		place *= 10
-	}
-
-	if negative {
-		return -val
-	}
-	return val
-}
-
-func printResults(stats map[string]*StationStats, duration time.Duration, fileSize int64) {
+func printResults(w io.Writer, stats map[string]StationStats) {
 	stationNames := make([]string, 0, len(stats))
 	for name := range stats {
 		stationNames = append(stationNames, name)
 	}
 	sort.Strings(stationNames)
 
-	var buffer bytes.Buffer
-	buffer.WriteString("{")
+	_, _ = fmt.Fprint(w, "{")
 	for i, name := range stationNames {
 		s := stats[name]
-		avg := float64(s.Sum) / float64(s.Count) / 10.0
-		buffer.WriteString(fmt.Sprintf("%s=%.1f/%.1f/%.1f", name, float64(s.Min)/10.0, avg, float64(s.Max)/10.0))
+		avg := float64(s.Sum) / float64(s.Count)
+		_, _ = fmt.Fprintf(w, "%s=%.2f/%.2f/%.2f", name, s.Min, avg, s.Max)
 		if i < len(stationNames)-1 {
-			buffer.WriteString(", ")
+			_, _ = fmt.Fprint(w, ", ")
 		}
 	}
-	buffer.WriteString("}\n")
+	_, _ = fmt.Fprint(w, "}\n")
+}
 
-	fmt.Print(buffer.String())
-
-	fmt.Printf("\nRESULTS\n")
-	fmt.Printf("Total Time: %v\n", duration)
+func printResultStats(w io.Writer, duration time.Duration, fileSize int64) {
+	_, _ = fmt.Fprintf(w, "\nRESULTS\n")
+	_, _ = fmt.Fprintf(w, "Total Time: %v\n", duration)
 	rowsPerSecond := float64(1_000_000_000) / duration.Seconds()
 	gbPerSecond := float64(fileSize) / (1024 * 1024 * 1024) / duration.Seconds()
-	fmt.Printf("Speed: %.2f million rows/second\n", rowsPerSecond/1_000_000)
-	fmt.Printf("I/O Rate: %.2f GB/second\n", gbPerSecond)
+	_, _ = fmt.Fprintf(w, "Speed: %.2f million rows/second\n", rowsPerSecond/1_000_000)
+	_, _ = fmt.Fprintf(w, "I/O Rate: %.2f GB/second\n", gbPerSecond)
 }
 
-func min(a, b int64) int64 {
-	if a < b {
-		return a
+func generate(file string) error {
+	generator := NewBillionRowGenerator()
+
+	if err := generator.LoadStations("weather_stations.csv"); err != nil {
+		return fmt.Errorf("loading stations: %v", err)
 	}
-	return b
+
+	if _, err := os.Stat(file); err == nil {
+		fmt.Printf("File %s already exists. Overwrite? (y/N): ", file)
+		var response string
+		_, _ = fmt.Scanln(&response)
+		if response != "y" && response != "Y" {
+			fmt.Println("Generation cancelled")
+			return nil
+		}
+	}
+
+	totalStart := time.Now()
+	if err := generator.Generate(file); err != nil {
+		return fmt.Errorf("generating data: %v", err)
+	}
+	totalDuration := time.Since(totalStart)
+
+	fmt.Printf("\nGENERATION COMPLETE\n")
+	fmt.Printf("Total time: %v\n", totalDuration)
+	return nil
 }
 
-func max(a, b int64) int64 {
-	if a > b {
-		return a
+func parseTemp(b string) (float64, bool) {
+	if len(b) < 4 { // min "0.00"
+		return 0, false
 	}
-	return b
+	i := 0
+	neg := false
+	if b[0] == '-' {
+		neg = true
+		i = 1
+		if len(b)-i < 4 { // need at least D.DD
+			return 0, false
+		}
+	}
+
+	// Detect dot position: i+1, i+2, or i+3
+	// and ensure we have exactly two digits after it.
+	var intv int32
+	switch {
+	case i+3 < len(b) && b[i+1] == '.': // D.DD
+		d0 := b[i+0] - '0'
+		d1 := b[i+2] - '0'
+		d2 := b[i+3] - '0'
+		if d0 > 9 || d1 > 9 || d2 > 9 {
+			return 0, false
+		}
+		intv = int32(d0)
+		frac := int32(d1)*10 + int32(d2)
+		v := intv*100 + frac
+		if neg {
+			v = -v
+		}
+		return float64(v) * 0.01, true
+
+	case i+4 < len(b) && b[i+2] == '.': // DD.DD
+		d0 := b[i+0] - '0'
+		d1 := b[i+1] - '0'
+		d2 := b[i+3] - '0'
+		d3 := b[i+4] - '0'
+		if d0 > 9 || d1 > 9 || d2 > 9 || d3 > 9 {
+			return 0, false
+		}
+		intv = int32(d0)*10 + int32(d1)
+		frac := int32(d2)*10 + int32(d3)
+		v := intv*100 + frac
+		if neg {
+			v = -v
+		}
+		return float64(v) * 0.01, true
+
+	case i+5 < len(b) && b[i+3] == '.': // DDD.DD (e.g. 100.00)
+		d0 := b[i+0] - '0'
+		d1 := b[i+1] - '0'
+		d2 := b[i+2] - '0'
+		d3 := b[i+4] - '0'
+		d4 := b[i+5] - '0'
+		if d0 > 9 || d1 > 9 || d2 > 9 || d3 > 9 || d4 > 9 {
+			return 0, false
+		}
+		intv = int32(d0)*100 + int32(d1)*10 + int32(d2)
+		frac := int32(d3)*10 + int32(d4)
+		v := intv*100 + frac
+		if neg {
+			v = -v
+		}
+		return float64(v) * 0.01, true
+	}
+
+	return 0, false
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMustRun(t *testing.T) {
+	p := makeFile(t, `stationA;10.00
+stationB;20.00
+stationA;30.00
+stationC;-1.00
+stationD;-99.99
+stationE;-999.99
+stationF;1.00
+`)
+
+	var stdout, stderr bytes.Buffer
+	err := MustRun([]string{"gobillion", "-f", p, "-w", "1"}, &stdout, &stderr)
+	require.NoError(t, err)
+
+	strOut, strErr := stdout.String(), stderr.String()
+
+	require.Contains(t, strOut, "stationA=10.00/20.00/30.00")
+	require.Contains(t, strOut, "stationB=20.00/20.00/20.00")
+	require.Contains(t, strOut, "stationC=-1.00/-1.00/-1.00")
+	require.Contains(t, strOut, "stationD=-99.99/-99.99/-99.99")
+	require.Contains(t, strOut, "stationE=-999.99/-999.99/-999.99")
+	require.Contains(t, strOut, "stationF=1.00/1.00/1.00")
+	require.Contains(t, strErr, "RESULTS")
+}
+
+func TestMustRunMalformedNumber(t *testing.T) {
+	p := makeFile(t, `stationA;NaN
+stationB;20.00
+stationA;30.00
+`)
+	err := MustRun([]string{"gobillion", "-f", p, "-w", "1"}, io.Discard, io.Discard)
+	require.ErrorContains(t, err, `malformed number: "NaN"`)
+}
+
+func TestMustRun_FailsOnMissingFile(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := MustRun([]string{"cmd", "-f", "nonexistent.txt"}, &stdout, &stderr)
+	require.ErrorContains(t, err, `file nonexistent.txt does not exist`)
+}
+
+func makeFile(t *testing.T, contents string) (path string) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "test.txt")
+	err := os.WriteFile(path, []byte(contents), 0644)
+	require.NoError(t, err)
+	return path
+}

--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -3,25 +3,31 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"syscall"
+	"unsafe"
 )
 
-func mmapFile(file *os.File) ([]byte, func(), error) {
+func mmapFile(file *os.File) (data string, cleanup func(), err error) {
 	fi, err := file.Stat()
 	if err != nil {
-		return nil, nil, err
+		return "", nil, err
 	}
 	fileSize := fi.Size()
 
-	data, err := syscall.Mmap(int(file.Fd()), 0, int(fileSize), syscall.PROT_READ, syscall.MAP_SHARED)
+	b, err := syscall.Mmap(
+		int(file.Fd()), 0, int(fileSize), syscall.PROT_READ, syscall.MAP_SHARED,
+	)
 	if err != nil {
-		return nil, nil, err
+		return "", nil, err
 	}
 
-	cleanup := func() {
-		syscall.Munmap(data)
+	cleanup = func() {
+		if err = syscall.Munmap(b); err != nil {
+			fmt.Printf("ERR: unmapping file: %v\n", err)
+		}
 	}
 
-	return data, cleanup, nil
+	return unsafe.String(&b[0], len(b)), cleanup, nil
 }

--- a/mmap_windows.go
+++ b/mmap_windows.go
@@ -3,34 +3,34 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
 )
 
-func mmapFile(file *os.File) ([]byte, func(), error) {
+func mmapFile(file *os.File) (data string, cleanup func(), err error) {
 	fi, err := file.Stat()
 	if err != nil {
-		return nil, nil, err
+		return "", nil, err
 	}
 	fileSize := fi.Size()
 
 	h, err := syscall.CreateFileMapping(syscall.Handle(file.Fd()), nil, syscall.PAGE_READONLY, 0, 0, nil)
 	if err != nil {
-		log.Fatalf("Error creating file mapping: %v", err)
+		return "", nil, fmt.Errorf("creating file mapping: %v", err)
 	}
 	addr, err := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, 0)
 	if err != nil {
-		log.Fatalf("Error mapping view of file: %v", err)
+		return "", nil, fmt.Errorf("mapping view of file: %v", err)
 	}
 
-	cleanup := func() {
+	cleanup = func() {
 		syscall.UnmapViewOfFile(addr)
 		syscall.CloseHandle(h)
 	}
 
-	data := unsafe.Slice((*byte)(unsafe.Pointer(addr)), fileSize)
+	data = unsafe.String((*byte)(unsafe.Pointer(addr)), fileSize)
 
 	return data, cleanup, nil
 }


### PR DESCRIPTION
The original code didn't parse the numbers properly, had no test coverage and maxed out at ~9s (warm) on Apple M4. This version is corrected and achieves higher performance:

```
Total Time: 4.845799s
Speed: 206.36 million rows/second
I/O Rate: 3.23 GB/second
```

- using `string` is faster than `[]byte` (likely due to the string header struct being slimmer)
- `readNameUntilSemicolon` is better at reading small names compared to std `IndexByte` on modern CPUs with decent branch prediction.
- `parseTemp` is optimized for small decimal numbers (ideally requires a fallback to `strconv.ParseFloat` though that I didn't add).
- adds more CLI flags to improve usability.